### PR TITLE
Retry deno deploy to survive intermittent CLI hang

### DIFF
--- a/justfile
+++ b/justfile
@@ -125,7 +125,26 @@ deploy: build
     cp -r worker/cache-test-utils.js $deploy/
     cp -r worker/static $deploy/
     cd $deploy
-    deno deploy --prod
+    # `deno deploy` (jsr:@deno/deploy) intermittently hangs mid-upload and is then
+    # killed by Deno's top-level-await watchdog with exit 1, even when nothing is
+    # wrong. Deploys create a fresh revision each time, so retry and treat the run
+    # as successful only when the CLI prints its genuine confirmation line.
+    attempts=3
+    for i in $(seq 1 $attempts); do
+      echo -e "{{ blue }}deno deploy attempt $i/$attempts{{ normal }}"
+      set +e
+      timeout 420 deno deploy --prod 2>&1 | tee deploy.log
+      code=${PIPESTATUS[0]}
+      set -e
+      if grep -q "Successfully deployed your application" deploy.log; then
+        echo -e "{{ green }}Deploy succeeded.{{ normal }}"
+        exit 0
+      fi
+      echo -e "{{ yellow }}Deploy attempt $i did not confirm success (exit $code); retrying...{{ normal }}"
+      sleep 5
+    done
+    echo -e "{{ magenta }}Deploy failed after $attempts attempts.{{ normal }}"
+    exit 1
 
 # Checks and tests
 test:


### PR DESCRIPTION
## Problem

The Deploy workflow on `main` failed for the #81 merge ([run 30050824182](https://github.com/metapages/framejs.io/actions/runs/30050824182/job/89372523397)), and also for an earlier push. Both failed at the `deno deploy` step with:

```
error: Top-level await promise never resolved
    await deployCommand.command("sandbox", sandboxCommand).reset().noExit()
    at <anonymous> (https://jsr.io/@deno/deploy/0.0.9904/main.ts:40:5)
```

This is an intermittent bug in `jsr:@deno/deploy@0.0.9904` (the version `deno deploy` currently pulls): the CLI hangs mid-upload and Deno's top-level-await watchdog kills the process with exit 1, failing the deploy. The same version deployed fine for the #80 merge, so it's flaky, not consistently broken.

## Fix

Wrap `deno deploy --prod` in a retry loop (up to 3 attempts). Each deploy creates a fresh revision, so retrying is safe. The run is considered successful **only** when the CLI prints its genuine confirmation line, `Successfully deployed your application` — the failed runs hang *before* that line, so the revision URL alone is not treated as success. A `timeout 420` guards against a true hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)